### PR TITLE
CSCQVAIN-136: Redirect to fairdata logout

### DIFF
--- a/cmd/qvain-backend/api.go
+++ b/cmd/qvain-backend/api.go
@@ -55,7 +55,11 @@ func NewApis(config *Config) *Apis {
 		metax.WithInsecureCertificates(config.DevMode))
 
 	apis.datasets = NewDatasetApi(config.db, config.sessions, metax, config.NewLogger("datasets"))
-	apis.sessions = NewSessionApi(config.sessions, config.NewLogger("sessions"))
+	apis.sessions = NewSessionApi(
+		config.sessions,
+		config.NewLogger("sessions"),
+		config.oidcProviderUrl+"/idp/profile/Logout",
+	)
 	apis.auth = NewAuthApi(config, makeOnFairdataLogin(metax, config.db, config.NewLogger("sync")), config.NewLogger("auth"))
 	apis.proxy = NewApiProxy(
 		"https://"+config.MetaxApiHost+"/rest/",

--- a/cmd/qvain-backend/session_api.go
+++ b/cmd/qvain-backend/session_api.go
@@ -10,13 +10,18 @@ import (
 
 // SessionApi allows users to access their session information.
 type SessionApi struct {
-	sessions *sessions.Manager
-	logger   zerolog.Logger
+	sessions       *sessions.Manager
+	logger         zerolog.Logger
+	logoutRedirect string // redirect after logout
 }
 
 // NewSessionApi creates a new SessionApi.
-func NewSessionApi(sessions *sessions.Manager, logger zerolog.Logger) *SessionApi {
-	return &SessionApi{sessions: sessions}
+func NewSessionApi(sessions *sessions.Manager, logger zerolog.Logger, logoutRedirect string) *SessionApi {
+	return &SessionApi{
+		sessions:       sessions,
+		logger:         logger,
+		logoutRedirect: logoutRedirect,
+	}
 }
 
 // Current dumps the (public) data from the current session in json format to the response.
@@ -63,6 +68,7 @@ func (api *SessionApi) Logout(w http.ResponseWriter, r *http.Request) {
 
 	enc.AppendByte('{')
 	enc.AddStringKey("msg", "User logged out succesfully")
+	enc.AddStringKey("redirect", api.logoutRedirect)
 	enc.AppendByte('}')
 	enc.Write()
 }

--- a/cmd/qvain-backend/session_api.go
+++ b/cmd/qvain-backend/session_api.go
@@ -47,17 +47,10 @@ func (api *SessionApi) Current(w http.ResponseWriter, r *http.Request) {
 
 // Logout deletes the current user session and returns a json response.
 func (api *SessionApi) Logout(w http.ResponseWriter, r *http.Request) {
-	sid, err := sessions.GetSessionCookie(r)
-	if err != nil {
-		api.logger.Debug().Err(err).Msg("no session cookie found")
-		sessionError(w, sessions.ErrSessionNotFound)
-		return
-	}
-	success := api.sessions.DestroyWithCookie(w, sid)
-	if !success {
-		api.logger.Debug().Msg("failed to destroy session")
-		sessionError(w, sessions.ErrSessionNotFound)
-		return
+	// If there is no session cookie or destroying session fails, assume
+	// it was already deleted and report successful logout.
+	if sid, err := sessions.GetSessionCookie(r); err == nil {
+		api.sessions.DestroyWithCookie(w, sid)
 	}
 
 	apiWriteHeaders(w)


### PR DESCRIPTION
Redirect after session has been deleted. Because the front-end uses a XHR call for logout so it can perform cleanup based on the result, we don't respond directly with a redirect but instead include the redirect url in the json response.