### PR TITLE
CSCQVAIN-224: Add user_created and user_modified when sending data to Metax

### DIFF
--- a/cmd/metax-cli/publish.go
+++ b/cmd/metax-cli/publish.go
@@ -29,11 +29,13 @@ func (s *stringsFlag) Set(val string) error {
 func runPublish(url string, args []string) error {
 	flags := flag.NewFlagSet("publish", flag.ExitOnError)
 	var (
-		ownerUuid uuidflag.Uuid
-		projects  stringsFlag
+		ownerUuid    uuidflag.Uuid
+		projects     stringsFlag
+		userIdentity string
 	)
 	flags.Var(&ownerUuid, "owner", "owner `uuid` to check dataset ownership against")
 	flags.Var(&projects, "projects", "comma-separated list of IDA projects used in the dataset")
+	flags.StringVar(&userIdentity, "identity", "cli-user", "user identity for the user_created and user_modified fields")
 
 	flags.Usage = usageFor(flags, "publish [flags] <id>")
 	if err := flags.Parse(args); err != nil {
@@ -68,6 +70,7 @@ func runPublish(url string, args []string) error {
 	owner := &models.User{
 		Uid:      ownerUuid.Get(),
 		Projects: projects,
+		Identity: userIdentity,
 	}
 	vId, nId, qId, err := shared.Publish(api, db, id, owner)
 	if err != nil {

--- a/cmd/qvain-backend/api_proxy.go
+++ b/cmd/qvain-backend/api_proxy.go
@@ -65,7 +65,7 @@ func checkProjectIdentifierMap(session *sessions.Session, m map[string]interface
 	return true
 }
 
-// checkProjectIdentifierMap checks project_identifiers in array recursively.
+// checkProjectIdentifierArray checks project_identifiers in array recursively.
 func checkProjectIdentifierArray(session *sessions.Session, a []interface{}) bool {
 	for _, v := range a {
 		switch vv := v.(type) {
@@ -82,10 +82,8 @@ func checkProjectIdentifierArray(session *sessions.Session, a []interface{}) boo
 	return true
 }
 
-// addUserCreatedModifiedToObject adds "user_created" or "user_modified" to the body
-// of a request that contains either:
-// - a json object
-// - an array of json objects
+// addPropertyToRequest adds a propetry to the root object in a json request,
+// or if the root is an array, to each of the objects in the array
 func addPropertyToRequest(r *http.Request, key string, value string) error {
 	// read body
 	body, err := ioutil.ReadAll(r.Body)
@@ -101,7 +99,7 @@ func addPropertyToRequest(r *http.Request, key string, value string) error {
 		return err
 	}
 
-	// set user_created or user_modified for the objects
+	// set the property for the objects
 	switch data := data.(type) {
 	case map[string]interface{}: // object
 		data[key] = value
@@ -270,7 +268,7 @@ func (api *ApiProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := addPropertyToRequest(r, key, session.User.Identity); err != nil {
-			jsonError(w, err.Error(), http.StatusForbidden)
+			jsonError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}

--- a/cmd/qvain-backend/api_proxy.go
+++ b/cmd/qvain-backend/api_proxy.go
@@ -44,7 +44,7 @@ func recorderToResponse(recorder *httptest.ResponseRecorder, response *http.Resp
 	response.Trailer = result.Trailer
 }
 
-// checkProjectIdentifierMap checks project_identifiers in map recursively.
+// checkProjectIdentifierMap checks project_identifiers in a map recursively.
 func checkProjectIdentifierMap(session *sessions.Session, m map[string]interface{}) bool {
 	for key, v := range m {
 		switch vv := v.(type) {
@@ -65,7 +65,7 @@ func checkProjectIdentifierMap(session *sessions.Session, m map[string]interface
 	return true
 }
 
-// checkProjectIdentifierArray checks project_identifiers in array recursively.
+// checkProjectIdentifierArray checks project_identifiers in an array recursively.
 func checkProjectIdentifierArray(session *sessions.Session, a []interface{}) bool {
 	for _, v := range a {
 		switch vv := v.(type) {
@@ -82,7 +82,7 @@ func checkProjectIdentifierArray(session *sessions.Session, a []interface{}) boo
 	return true
 }
 
-// addPropertyToRequest adds a propetry to the root object in a json request,
+// addPropertyToRequest adds a property to the root object of a json request,
 // or if the root is an array, to each of the objects in the array
 func addPropertyToRequest(r *http.Request, key string, value string) error {
 	// read body
@@ -117,9 +117,8 @@ func addPropertyToRequest(r *http.Request, key string, value string) error {
 	if err != nil {
 		return err
 	}
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 	r.ContentLength = int64(len(body))
-
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(body)) // make body readable again
 	return nil
 }
 
@@ -257,11 +256,11 @@ func (api *ApiProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// use allowed_projects parameter for non-GET requests
 	if r.Method != http.MethodGet {
+		// use allowed_projects parameter for non-GET requests
 		r.URL.RawQuery = session.User.AddAllowedProjects(r.URL.RawQuery)
 
-		// assume new objects are being created if method is POST, so user_created will be used
+		// assume new objects are being created if method is POST
 		key := "user_created"
 		if r.Method != http.MethodPost {
 			key = "user_modified"

--- a/cmd/qvain-backend/api_proxy_test.go
+++ b/cmd/qvain-backend/api_proxy_test.go
@@ -49,7 +49,7 @@ func errorResponse(request *http.Request, msg string, code int) *http.Response {
 	return response
 }
 
-// checkField checks the json request root object contains a property with a specific value. If
+// checkProperty checks the json request root object contains a property with a specific value. If
 // the json object contains an array, each object in the array is checked.
 func checkProperty(r *http.Request, key string, value string) bool {
 	// read body

--- a/cmd/qvain-backend/api_proxy_test.go
+++ b/cmd/qvain-backend/api_proxy_test.go
@@ -58,6 +58,7 @@ func checkProperty(r *http.Request, key string, value string) bool {
 		return false
 	}
 	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body)) // make body readable again
 
 	// parse json
 	var data interface{}

--- a/cmd/qvain-backend/api_proxy_test.go
+++ b/cmd/qvain-backend/api_proxy_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +30,13 @@ var (
 		"9": `{"testing": {"nesting": [ {foo: "bar"}, {"project_identifier": "1"}]}}`, // missing quotes in key
 	}
 
+	requestBodies = map[string]string{
+		"object": `{"identifier":"1", "file_characteristics": {"title":"Whee"}}`,
+		"array": `[{"identifier":"1", "file_characteristics": {"title":"Whee"}},` +
+			`{"identifier":"2", "file_characteristics": {"title":"Whoo"}}]`,
+	}
+
+	userIdentity = "user"
 	userProjects = []string{"1", "2"}
 )
 
@@ -38,6 +47,43 @@ func errorResponse(request *http.Request, msg string, code int) *http.Response {
 	response.StatusCode = code
 	response.Request = request
 	return response
+}
+
+// checkField checks the json request root object contains a property with a specific value. If
+// the json object contains an array, each object in the array is checked.
+func checkProperty(r *http.Request, key string, value string) bool {
+	// read body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body.Close()
+
+	// parse json
+	var data interface{}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return false
+	}
+
+	// check key-value pair
+	switch data := data.(type) {
+	case map[string]interface{}: // object
+		if v, ok := data[key].(string); !ok || v != value {
+			return false
+		}
+
+	case []interface{}: // array of objects
+		for _, object := range data {
+			if object, isObject := object.(map[string]interface{}); isObject {
+				if v, ok := object[key].(string); !ok || v != value {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
 }
 
 // DummyRoundTripper acts as a dummy replacement for the external Metax server.
@@ -83,6 +129,17 @@ func (rt *DummyRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		}
 	}
 
+	if request.Method != http.MethodGet {
+		field := "user_created"
+		if request.Method != http.MethodPost {
+			field = "user_modified"
+		}
+		if !checkProperty(request, field, userIdentity) {
+			response := errorResponse(request, fmt.Sprintf("missing %s in request", field), http.StatusBadRequest)
+			return response, nil
+		}
+	}
+
 	recorder := httptest.NewRecorder()
 	recorder.WriteString(responses[query.Get("response")])
 	response := recorder.Result()
@@ -102,10 +159,13 @@ func NewDummyProxy(logger zerolog.Logger, sessionsManager *sessions.Manager) *ht
 type RequestConfig struct {
 	NoSession bool
 	Method    string
+	Body      string
 }
 
 // tryRequest creates a request for ApiProxy.ServeHTTP and checks the response
 func tryRequest(t *testing.T, url string, config RequestConfig, expectedStatus int) string {
+	t.Helper() // ignore this function when printing line numbers for errors
+
 	logger := zerolog.Nop() // don't print logs
 	sessionsManager := sessions.NewManager()
 	api := &ApiProxy{
@@ -120,6 +180,7 @@ func tryRequest(t *testing.T, url string, config RequestConfig, expectedStatus i
 		&uuid,
 		&models.User{
 			Projects: userProjects,
+			Identity: userIdentity,
 		},
 	)
 
@@ -128,10 +189,16 @@ func tryRequest(t *testing.T, url string, config RequestConfig, expectedStatus i
 		method = config.Method
 	}
 
-	request, _ := http.NewRequest(method, url, new(bytes.Buffer)) // create request with empty body
+	request, _ := http.NewRequest(method, url, new(bytes.Buffer)) // create request
 	if !config.NoSession {
 		request.Header.Add("Cookie", "sid="+sid) // add session cookie
 	}
+
+	// add body to request
+	if config.Body != "" {
+		request.Body = ioutil.NopCloser(bytes.NewBuffer([]byte(config.Body)))
+	}
+
 	writer := httptest.NewRecorder() // writer will contain the response
 	api.ServeHTTP(writer, request)   // make the request
 
@@ -181,7 +248,21 @@ func TestApiProxy(t *testing.T) {
 	// ok, use PATCH method
 	tryRequest(t,
 		"/files/fakeurl?project=1&response=1",
-		RequestConfig{Method: http.MethodPatch},
+		RequestConfig{Method: http.MethodPatch, Body: requestBodies["object"]},
+		http.StatusOK,
+	)
+
+	// ok, use PATCH method for array
+	tryRequest(t,
+		"/files/fakeurl?project=1&response=1",
+		RequestConfig{Method: http.MethodPatch, Body: requestBodies["array"]},
+		http.StatusOK,
+	)
+
+	// ok, use POST method
+	tryRequest(t,
+		"/files/fakeurl?project=1&response=1",
+		RequestConfig{Method: http.MethodPost, Body: requestBodies["object"]},
 		http.StatusOK,
 	)
 

--- a/cmd/qvain-backend/api_proxy_test.go
+++ b/cmd/qvain-backend/api_proxy_test.go
@@ -49,7 +49,7 @@ func errorResponse(request *http.Request, msg string, code int) *http.Response {
 	return response
 }
 
-// checkProperty checks the json request root object contains a property with a specific value. If
+// checkProperty checks that the json request root object contains a property with a specific value. If
 // the json object contains an array, each object in the array is checked.
 func checkProperty(r *http.Request, key string, value string) bool {
 	// read body

--- a/internal/psql/dataset.go
+++ b/internal/psql/dataset.go
@@ -471,9 +471,9 @@ func (tx *Tx) get(id uuid.UUID, key string) (*models.Dataset, error) {
 
 	res := new(models.Dataset)
 	if key == "" {
-		err = tx.QueryRow("select id, creator, owner, family, schema, blob from datasets where id=$1", id.Array()).Scan(res.Id.Array(), res.Creator.Array(), res.Owner.Array(), &family, &schema, &blob)
+		err = tx.QueryRow("select id, creator, owner, family, schema, published, blob from datasets where id=$1", id.Array()).Scan(res.Id.Array(), res.Creator.Array(), res.Owner.Array(), &family, &schema, &res.Published, &blob)
 	} else {
-		err = tx.QueryRow(`select id, creator, owner, family, schema, blob#>$2 from datasets where id=$1`, id.Array(), []string{key}).Scan(res.Id.Array(), res.Creator.Array(), res.Owner.Array(), &family, &schema, &blob)
+		err = tx.QueryRow(`select id, creator, owner, family, schema, published, blob#>$2 from datasets where id=$1`, id.Array(), []string{key}).Scan(res.Id.Array(), res.Creator.Array(), res.Owner.Array(), &family, &schema, &res.Published, &blob)
 	}
 	if err != nil {
 		return nil, handleError(err)

--- a/internal/shared/publish.go
+++ b/internal/shared/publish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CSCfi/qvain-api/internal/psql"
 	"github.com/CSCfi/qvain-api/pkg/metax"
 	"github.com/CSCfi/qvain-api/pkg/models"
+	"github.com/tidwall/sjson"
 	"github.com/wvh/uuid"
 )
 
@@ -28,12 +29,23 @@ func Publish(api *metax.MetaxService, db *psql.DB, id uuid.UUID, owner *models.U
 		return
 	}
 
+	// Add user_created or user_modified based on whether this was already published
+	blob := dataset.Blob()
+	if dataset.Published {
+		blob, err = sjson.SetBytes(blob, "user_modified", owner.Identity)
+	} else {
+		blob, err = sjson.SetBytes(blob, "user_created", owner.Identity)
+	}
+	if err != nil {
+		return
+	}
+
 	fmt.Fprintln(os.Stderr, "About to publish:", id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	res, err := api.Store(ctx, dataset.Blob(), owner)
+	res, err := api.Store(ctx, blob, owner)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "type: %T\n", err)
 		if apiErr, ok := err.(*metax.ApiError); ok {

--- a/internal/shared/publish_test.go
+++ b/internal/shared/publish_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/CSCfi/qvain-api/pkg/models"
 	"github.com/tidwall/gjson"
 
-	"github.com/tidwall/gjson"
 	"github.com/wvh/uuid"
 )
 

--- a/internal/shared/publish_test.go
+++ b/internal/shared/publish_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/CSCfi/qvain-api/pkg/env"
 	"github.com/CSCfi/qvain-api/pkg/metax"
 	"github.com/CSCfi/qvain-api/pkg/models"
+	"github.com/tidwall/gjson"
 
 	"github.com/wvh/uuid"
 )
 
-var ownerUuid = uuid.MustFromString("053bffbcc41edad4853bea91fc42ea18")
+var (
+	ownerUuid        = uuid.MustFromString("053bffbcc41edad4853bea91fc42ea18")
+	ownerIdentity    = "owner"
+	modifierIdentity = "modifier"
+)
 
 func readFile(tb testing.TB, fn string) []byte {
 	path := filepath.Join("..", "..", "pkg", "metax", "testdata", fn)
@@ -93,16 +98,25 @@ func TestPublish(t *testing.T) {
 
 	owner := &models.User{
 		Uid:      ownerUuid,
+		Identity: ownerIdentity,
+		Projects: []string{"project_x"},
+	}
+
+	modifier := &models.User{
+		Uid:      ownerUuid,
+		Identity: modifierIdentity,
 		Projects: []string{"project_x"},
 	}
 
 	wrongProjectOwner := &models.User{
 		Uid:      ownerUuid,
+		Identity: ownerIdentity,
 		Projects: []string{"wrong_project_x_y_z"},
 	}
 
 	noProjectOwner := &models.User{
 		Uid:      ownerUuid,
+		Identity: ownerIdentity,
 		Projects: []string{},
 	}
 
@@ -156,6 +170,15 @@ func TestPublish(t *testing.T) {
 
 			t.Logf("published with version id %q", vId)
 			versionId = vId
+
+			// check that the dataset has been updated with a user_created field
+			publishedDataset, err := db.Get(id)
+			if err != nil {
+				t.Error("error retrieving dataset:", err)
+			}
+			if userCreated := gjson.GetBytes(publishedDataset.Blob(), "user_created").String(); userCreated != owner.Identity {
+				t.Error("missing or wrong user_created", userCreated)
+			}
 		})
 
 		err = modifyTitleFromDataset(db, id, "Less Wonderful Title")
@@ -165,7 +188,7 @@ func TestPublish(t *testing.T) {
 
 		// test that should update
 		t.Run(test.fn+"(update)", func(t *testing.T) {
-			vId, nId, _, err := Publish(api, db, id, owner)
+			vId, nId, _, err := Publish(api, db, id, modifier)
 			if err != nil {
 				if apiErr, ok := err.(*metax.ApiError); ok {
 					t.Errorf("API error: [%d] %s", apiErr.StatusCode(), apiErr.Error())
@@ -182,6 +205,16 @@ func TestPublish(t *testing.T) {
 			}
 
 			t.Logf("(re)published with version id %q", vId)
+
+			// check that the dataset has been updated with a user_modified field
+			publishedDataset, err := db.Get(id)
+			if err != nil {
+				t.Error("error retrieving dataset:", err)
+			}
+
+			if userModified := gjson.GetBytes(publishedDataset.Blob(), "user_modified").String(); userModified != modifier.Identity {
+				t.Error("missing or wrong user_modified:", userModified)
+			}
 		})
 
 		err = deleteFilesFromFairdataDataset(db, id)
@@ -191,7 +224,7 @@ func TestPublish(t *testing.T) {
 
 		// test that should remove files and create a new version
 		t.Run(test.fn+"(files)", func(t *testing.T) {
-			vId, nId, qId, err := Publish(api, db, id, owner)
+			vId, nId, qId, err := Publish(api, db, id, modifier)
 			if err != nil {
 				if apiErr, ok := err.(*metax.ApiError); ok {
 					t.Errorf("API error: [%d] %s", apiErr.StatusCode(), apiErr.Error())
@@ -210,6 +243,15 @@ func TestPublish(t *testing.T) {
 			}
 
 			t.Logf("(re)published with version id %q", vId)
+
+			// the new version should have the user who modified the dataset as user_created
+			publishedDataset, err := db.Get(*qId)
+			if err != nil {
+				t.Error("error retrieving dataset:", err)
+			}
+			if userCreated := gjson.GetBytes(publishedDataset.Blob(), "user_created").String(); userCreated != modifier.Identity {
+				t.Error("missing or wrong user_created: ", userCreated)
+			}
 		})
 
 		// if we want to make it invalid again...


### PR DESCRIPTION
This adds a user_created (for new data) or user_modified (for existing data) field on dataset publication or when proxy is used with a non-GET request. 